### PR TITLE
An alternative method to calculate adjusted growth rate

### DIFF
--- a/Source/AnimalMetricsLib/AnimalMetricsLib.Main/Interfaces/IAdjustedGrowthRateCalculator.cs
+++ b/Source/AnimalMetricsLib/AnimalMetricsLib.Main/Interfaces/IAdjustedGrowthRateCalculator.cs
@@ -8,4 +8,6 @@ namespace AnimalMetricsLib.Interfaces;
 public interface IAdjustedGrowthRateCalculator
 {
     double CalculateAdjustedGrowthRate(Animal animal, NutritionInfo nutritionInfo);
+    double CalculateAdjustedGrowthRate(List<GrowthMeasurement> measurements, 
+        NutritionInfo nutritionInfo);
 }

--- a/Source/AnimalMetricsLib/AnimalMetricsLib.Main/Models/AdjustmentFactors.cs
+++ b/Source/AnimalMetricsLib/AnimalMetricsLib.Main/Models/AdjustmentFactors.cs
@@ -16,4 +16,13 @@ public class AdjustmentFactors
     private double EnergyContentAdjustmentFactor => ActualEnergyContent / RequiredEnergyContent;
     private double VitaminMineralIndexAdjustmentFactor => ActualVitaminMineralIndex / RequiredVitaminMineralIndex;
     public double OverallAdjustmentFactor => (ProteinContentAdjustmentFactor + EnergyContentAdjustmentFactor + VitaminMineralIndexAdjustmentFactor) / 3;
+    public static implicit operator AdjustmentFactors(NutritionInfo nutritionInfo)
+        => new AdjustmentFactors() {
+            ActualProteinContent = nutritionInfo.ActualProteinContent,
+            RequiredProteinContent = nutritionInfo.RequiredProteinContent,
+            ActualEnergyContent = nutritionInfo.ActualEnergyContent,
+            RequiredEnergyContent = nutritionInfo.RequiredEnergyContent,
+            ActualVitaminMineralIndex = nutritionInfo.ActualVitaminMineralIndex,
+            RequiredVitaminMineralIndex = nutritionInfo.RequiredVitaminMineralIndex
+        };
 }

--- a/Source/AnimalMetricsLib/AnimalMetricsLib.Main/Models/GrowthMeasurement.cs
+++ b/Source/AnimalMetricsLib/AnimalMetricsLib.Main/Models/GrowthMeasurement.cs
@@ -1,0 +1,10 @@
+namespace AnimalMetricsLib.Models;
+
+/// <summary>
+/// Represents an animal weight at a specific point in time
+/// </summary>
+public class GrowthMeasurement
+{
+    public double Weight { get; set; }
+    public DateTime MeasurementDate { get; set; }
+}

--- a/Source/AnimalMetricsLib/AnimalMetricsLib.Tests/Services/AdjustedGrowthRateCalculatorTest.cs
+++ b/Source/AnimalMetricsLib/AnimalMetricsLib.Tests/Services/AdjustedGrowthRateCalculatorTest.cs
@@ -2,13 +2,59 @@
 using AnimalMetricsLib.Services;
 using AnimalMetricsLib.Models;
 using System;
+using AnimalMetricsLib.Interfaces;
+using System.Collections.Generic;
 
 namespace AnimalMetricsLib.Tests.Services
 {
     public class AdjustedGrowthRateCalculatorTest
     {
-        private readonly AdjustedGrowthRateCalculator _growthRateCalculator = new AdjustedGrowthRateCalculator();
+        private readonly IAdjustedGrowthRateCalculator _growthRateCalculator = new AdjustedGrowthRateCalculator();
+        // Test Data for Calculate Adjusted Growth Rate from Measurements
+        public static IEnumerable<object[]> GrowthMeasurementData() 
+            => new List<object[]> {
+                // Empty set of measurments
+                new object[] {
+                    new List<GrowthMeasurement>(),
+                    new NutritionInfo(),
+                    0
+                },
+                // If NutritionInfo values are 0, then result is expected to be
+                // NaN since things like OverallAdjustmentFactor can't be calculated.
+                // Not sure if this is intended behavior or a bug.
+                new object[] {
+                    new List<GrowthMeasurement>() {
+                        new GrowthMeasurement() {
+                            Weight = 10, MeasurementDate = DateTime.Now
+                        }
+                    },
+                    new NutritionInfo(),
+                    double.NaN
+                },
+                // Test with a few valid measurements and valid nutrition information
+                new object[] {
+                    new List<GrowthMeasurement>() {
+                        new GrowthMeasurement() {
+                            Weight = 10, MeasurementDate = new DateTime(2023, 12, 15, 9, 0, 0)
+                        },
+                        new GrowthMeasurement() {
+                            Weight = 15, MeasurementDate = new DateTime(2024, 1, 5, 11, 0, 0)
+                        },
+                        new GrowthMeasurement() {
+                            Weight = 20, MeasurementDate = new DateTime(2024, 2, 3, 7, 0, 0)
+                        }
+                    },
+                    new NutritionInfo() {
+                        ActualProteinContent = 10,
+                        RequiredProteinContent = 1,
+                        ActualEnergyContent = 10,
+                        RequiredEnergyContent = 1,
+                        ActualVitaminMineralIndex = 10,
+                        RequiredVitaminMineralIndex = 1
+                    }, 2.00
+                }
 
+            };
         [Theory]
         [InlineData(10.0, 20.0, 10, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)] // Basic growth condition
         [InlineData(20.0, 40.0, 10, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0)] // Extended growth condition
@@ -44,5 +90,19 @@ namespace AnimalMetricsLib.Tests.Services
 
             _growthRateCalculator.CalculateAdjustedGrowthRate(animal, nutritionInfo);
         }
+        [Theory]
+        [MemberData(nameof(GrowthMeasurementData))]
+        public void CalculateAdjustedGrowthRateFromMeasurements(
+            List<GrowthMeasurement> measurements, 
+            NutritionInfo nutritionInfo,
+            double expectedResult) 
+        {
+            var result = _growthRateCalculator.CalculateAdjustedGrowthRate(
+                measurements, nutritionInfo);
+            result = Math.Round(result, 2);
+            Assert.Equal(expectedResult, result);
+        }
+
+
     }
 }


### PR DESCRIPTION
Added method to calculate adjusted growth rate based on a series of m measurements or weigh ins.  Switched AdjustmentFactors to an implicit conversion.  Expanded tests to cover new feature.